### PR TITLE
Add error stripe color to warning and error attributes

### DIFF
--- a/src/main/resources/colors/NightOwl.xml
+++ b/src/main/resources/colors/NightOwl.xml
@@ -760,6 +760,7 @@
         <option name="ERRORS_ATTRIBUTES">
             <value>
                 <option name="FOREGROUND" value="ef5350"/>
+                <option name="ERROR_STRIPE_COLOR" value="ef5350"/>
                 <option name="EFFECT_TYPE" value="2"/>
             </value>
         </option>
@@ -3678,6 +3679,7 @@
         <option name="WARNING_ATTRIBUTES">
             <value>
                 <option name="FOREGROUND" value="b39554"/>
+                <option name="ERROR_STRIPE_COLOR" value="b39554"/>
                 <option name="EFFECT_TYPE" value="2"/>
             </value>
         </option>


### PR DESCRIPTION
Error and warning stripes were hidden on the right side of the editor without these options.